### PR TITLE
Fix network interface parsing for 64-bit systems

### DIFF
--- a/CWStevens.c
+++ b/CWStevens.c
@@ -220,19 +220,9 @@ struct ifi_info* get_ifi_info(int family, int doaliases)
 #ifdef	HAVE_SOCKADDR_SA_LEN
 		len = max(sizeof(struct sockaddr), ifr->ifr_addr.sa_len);
 #else
-		switch (ifr->ifr_addr.sa_family) {
-#ifdef	IPV6
-		case AF_INET6:	
-			len = sizeof(struct sockaddr_in6);
-			break;
-#endif
-		case AF_INET:	
-		default:	
-			len = sizeof(struct sockaddr);
-			break;
-		}
+		len = sizeof *ifr;
 #endif	/* HAVE_SOCKADDR_SA_LEN */
-		ptr += sizeof(ifr->ifr_name) + len;	/* for next one in buffer */
+		ptr += len;	/* for next one in buffer */
 
 #ifdef	HAVE_SOCKADDR_DL_STRUCT
 		/* assumes that AF_LINK precedes AF_INET or AF_INET6 */


### PR DESCRIPTION
Not sure if this is 100% correct, I'm basing the patch off the code in [here](https://gist.github.com/OrangeTide/909204) which demos how to use the SIOCGIFCONF ioctl.

Compiling on a 64-bit system shows now finds the network interface and starts the AC correctly.

Fixes #20

/cc @e-ago @tootellz