### PR TITLE
Fix rate in beacon frames

### DIFF
--- a/CW80211InformationElements.c
+++ b/CW80211InformationElements.c
@@ -246,8 +246,8 @@ CWBool CW80211AssembleIESupportedRates(char * frame, int * offset, char * value,
 	
 	if(numRates <= 0)
 		return CW_FALSE;
-		
-	CW_COPY_MEMORY((frame+IE_TYPE_LEN), &(numRates), IE_SIZE_LEN);
+	unsigned char len = numRates;	
+	CW_COPY_MEMORY((frame+IE_TYPE_LEN), &(len), IE_SIZE_LEN);
 	(*offset) += IE_SIZE_LEN;
 	/*int i=0;
 	for(i=0; i<numRates; i++)


### PR DESCRIPTION
Tag length should be 0x12 but was being observed as set to 0x00 due to type mismatch. `numRates` is an int, and therefore would be larger than a single byte, leading to the CW_COPY_MEMORY copying only the first byte of the int, being 0x00. After this change, the beacon is correctly parsed in Wireshark.