### PR TITLE
update iterator in get_ifi_info() otherwise AC may only see loopback …

### DIFF
--- a/CWStevens.c
+++ b/CWStevens.c
@@ -232,7 +232,7 @@ struct ifi_info* get_ifi_info(int family, int doaliases)
 			break;
 		}
 #endif	/* HAVE_SOCKADDR_SA_LEN */
-		ptr += sizeof(ifr->ifr_name) + len;	/* for next one in buffer */
+		ptr += sizeof(struct ifreq);	/* for next one in buffer */
 
 #ifdef	HAVE_SOCKADDR_DL_STRUCT
 		/* assumes that AF_LINK precedes AF_INET or AF_INET6 */


### PR DESCRIPTION
In my laptop I have 2 physical interface card plus lo but AC will only see 'lo' because the iterator step calculation is wrong(I don't know why there is no such issue reported)